### PR TITLE
Do not stop mongo in case serverless offline is spawned in a child process by e.g. Jest

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,10 @@ class ServerlessMongoDBLocal {
 
   async stopHandler() {
     if (this.shouldExecute()) {
+      // Do not stop it in case JEST is running tests
+      // (or serverless was spawned in child process by NodeJS)
+      // It will be automatically killed with the parent process.
+      if (process.env.NODE_ENV === 'test') { return; }
       this.log('Stopping local database');
       try {
         await this.mongod.stop();


### PR DESCRIPTION
While implementing the tests with Jest and spawning the serverless-offline in a separate process ( like here - https://github.com/dherault/serverless-offline/blob/master/tests/integration/_testHelpers/setupTeardown.js ) I noticed that local mongo was stopped every time after serverless finished its startup.
So, it appears that (not sure if this is the only case) if serverless is started in a child process it sends the `end` hook after the start is completed. This hook made the local mongo stop.
After some digging, I found this in the serverless-offline code:
```
async end(skipExit) {
    // TEMP FIXME
    if (env.NODE_ENV === 'test' && skipExit === undefined) {
      return
    }
....
}
```
So, they are handling this case for their Jest tests as well...